### PR TITLE
google sign in - also creates an account...

### DIFF
--- a/src/components/admin-pages/AdminLogin.js
+++ b/src/components/admin-pages/AdminLogin.js
@@ -16,12 +16,10 @@ const AdminLogin = ({ history }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [, setErrors] = useState('');
-
   const Auth = useContext(AuthContext);
 
   const handleForm = (e) => {
     e.preventDefault();
-    console.log(Auth);
     firebase
       .auth()
       .setPersistence(firebase.auth.Auth.Persistence.SESSION)
@@ -40,11 +38,11 @@ const AdminLogin = ({ history }) => {
   };
 
   const signInWithGoogle = () => {
-    const provider = new firebase.auth.GoogleAuthProvider();
     firebase
       .auth()
       .setPersistence(firebase.auth.Auth.Persistence.SESSION)
       .then(() => {
+        const provider = new firebase.auth.GoogleAuthProvider();
         firebase
           .auth()
           .signInWithPopup(provider)


### PR DESCRIPTION
after researching this issue, it is something that is bc of the way firebase is, the only work around is through the firebase console under the rules, users will still be able to create an account but will not be able to add to the inventory based on the rules I have applied